### PR TITLE
fix: 補上餐廳經緯度資訊於訂單項目

### DIFF
--- a/server/api/orders/[id]/index.get.ts
+++ b/server/api/orders/[id]/index.get.ts
@@ -57,6 +57,9 @@ import { verifyJwtFromEvent } from '@server/utils/auth'
  *                     restaurant:
  *                       name: "傑哥加長加長菜"
  *                       phone: "02-1234-5678"
+ *                       location:
+ *                         lat: 25.1508
+ *                         lng: 121.7730
  *                 deliveryInfo:
  *                   address: "基隆市中正區OO路123號"
  *                   contactName: "宋辰星"

--- a/server/api/swagger.components.ts
+++ b/server/api/swagger.components.ts
@@ -120,7 +120,14 @@ export const components = {
                             name: { type: 'string' }
                             ,
                             phone: { type: 'string' },
-                            address: { type: 'string' }
+                            address: { type: 'string' },
+                            location: {
+                                type: 'object',
+                                properties: {
+                                    lat: { type: 'number' },
+                                    lng: { type: 'number' }
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This pull request enhances the `GET /orders/[id]` API endpoint by ensuring that each item's restaurant information includes geographic coordinates (latitude and longitude). This makes it easier for consumers of the API to access restaurant location data directly in the response.

**Enhancements to restaurant location data:**

* Populates the `locationGeo` field for each item's restaurant by updating the Mongoose query to include `items.restaurant.id` with the `locationGeo` field. ([server/api/orders/[id]/index.get.tsR81](diffhunk://#diff-2556cfd1ccb410d6f2404fab7f6bfb29da23c3b0fb11a07e3f3a6e2a09a463d5R81))
* Adds logic to extract latitude and longitude from `locationGeo.coordinates` and attaches them as a `location` object (`{ lat, lng }`) to each item's restaurant, also normalizing the `id` field to just the `_id` value. ([server/api/orders/[id]/index.get.tsR96-R106](diffhunk://#diff-2556cfd1ccb410d6f2404fab7f6bfb29da23c3b0fb11a07e3f3a6e2a09a463d5R96-R106))