### PR TITLE
Feature/yuan dc notify to main

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -23,12 +23,12 @@ on:
 
 jobs:
     notify:
-        runs-on: ubuntu-slim
+        runs-on: ubuntu-latest
 
         steps:
             - name: Send embed to Discord
               env:
-                  DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+                  DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
                   EVENT: ${{ github.event_name }}
                   ACTOR: ${{ github.actor }}
                   AVATAR_URL: https://github.com/${{ github.actor }}.png


### PR DESCRIPTION
這個 Pull Request 新增了一個 GitHub Actions 工作流程，用於在多種倉庫事件發生時，將具備豐富嵌入格式的通知傳送至 Discord。該流程涵蓋推送、Pull Request、Issue、評論、星標及分叉等事件，並提供即時且具備上下文的更新訊息。

*註：由於 GitHub Actions 僅會使用 `main` 分支中的 workflow，因此重新提交此 PR。*

