### PR TITLE
fix:更新 Discord 通知工作流程設定

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -23,12 +23,12 @@ on:
 
 jobs:
     notify:
-        runs-on: ubuntu-slim
+        runs-on: ubuntu-latest
 
         steps:
             - name: Send embed to Discord
               env:
-                  DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+                  DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
                   EVENT: ${{ github.event_name }}
                   ACTOR: ${{ github.actor }}
                   AVATAR_URL: https://github.com/${{ github.actor }}.png


### PR DESCRIPTION
將執行環境從 `ubuntu-slim` 改為 `ubuntu-latest`，並將 Discord Webhook 的秘密變數引用更新為 `DISCORD_WEBHOOK`。